### PR TITLE
i fixed a bug but then i found some fun new bugs 🐛 [edit: then i fixed them too]

### DIFF
--- a/fica/src/main.rs
+++ b/fica/src/main.rs
@@ -61,7 +61,7 @@ fn ord(num: usize) -> &'static str {
 		"th"
 	} else {
 		// teens - ordinals
-		["th", "th", "st", "nd", "rd", "th"][(num % 10).min(4) + 1]
+		["th", "st", "nd", "rd", "th"][(num % 10).min(4)]
 	}
 }
 

--- a/fica/src/main.rs
+++ b/fica/src/main.rs
@@ -54,6 +54,7 @@ fn print_date(date: Date) {
 }
 
 fn ord(num: usize) -> &'static str {
+	let num = num % 100; //ordinals repeat every 100
 	if (10..=19).contains(&num) {
 		// i'd like to make this fucked up math + min/max in the index if i can
 		// but that is apparently difficult

--- a/fica/src/main.rs
+++ b/fica/src/main.rs
@@ -105,4 +105,17 @@ mod test {
 		assert_eq!(ord(2453), "rd");
 		assert_eq!(ord(2341), "st");
 	}
+
+	#[test]
+	fn weird_ord_high_teens() {
+		assert_eq!(ord(111), "th", "should be one hundred and eleventh");
+		assert_eq!(ord(112), "th");
+		assert_eq!(ord(113), "th");
+		assert_eq!(ord(114), "th");
+		assert_eq!(ord(115), "th");
+		assert_eq!(ord(116), "th");
+		assert_eq!(ord(117), "th");
+		assert_eq!(ord(118), "th");
+		assert_eq!(ord(119), "th");
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,15 +110,16 @@ impl From<time::Date> for Date {
 	fn from(date: time::Date) -> Self {
 		let year = date.year() as u32;
 		let ord = date.ordinal() - 1;
+		let leap = year_leaps(year);
 
-		if year_leaps(year) && ord == 168 {
+		if leap && ord == 168 {
 			// Catch the leap day
 			return Self {
 				year,
 				month: 6,
 				day: 29,
 			};
-		} else if ord == 364 || ord == 365 {
+		} else if (!leap && ord == 364) || ord == 365 {
 			// Catch both year days
 			return Self {
 				year,
@@ -127,7 +128,7 @@ impl From<time::Date> for Date {
 			};
 		}
 
-		if !year_leaps(year) || ord <= 168 {
+		if !leap || ord <= 168 {
 			// not a leap year path
 			// also the "leap year but before the leap-day" path
 			Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,9 @@ mod test {
 		// Sol
 		check!(06 - 18, 07 - 01);
 		check!(07 - 15, 07 - 28);
+		//leap years don't change conversion after leap day
+		check!(leap 06 - 18, 07 - 01);
+		check!(leap 07 - 15, 07 - 28);
 
 		// July
 		check!(07 - 16, 08 - 01);
@@ -318,13 +321,15 @@ mod test {
 		// December
 		check!(12 - 03, 13 - 01);
 		check!(12 - 30, 13 - 28);
+		check!(leap 12 - 30, 13 - 28);
 
 		// Year Day
-		check!(12 - 31, 13 - 29)
+		check!(12 - 31, 13 - 29);
+		check!(leap 12 - 31, 13 - 29);
 	}
 
 	#[test]
-	fn known_culprits() -> Result<(), time::error::ComponentRange> {
+	fn round_trip_known_culprits() -> Result<(), time::error::ComponentRange> {
 		let mut ifc: crate::Date;
 		let june_17th_2024 = time::Date::from_calendar_date(2024, time::Month::June, 17)?;
 		ifc = june_17th_2024.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,8 @@ impl Date {
 	pub fn ordinal(&self) -> u16 {
 		let ord = (self.month as u16 - 1) * 28 + self.day as u16;
 
-		if self.is_leap() && ord >= 169 {
+		//if leap year and the day is on/after leap day and it isn't leap day
+		if self.is_leap() && ord >= 169 && !(self.month == 6 && self.day == 29) {
 			ord + 1
 		} else {
 			ord
@@ -334,7 +335,12 @@ mod test {
 		let mut ifc: crate::Date;
 		let june_17th_2024 = time::Date::from_calendar_date(2024, time::Month::June, 17)?;
 		ifc = june_17th_2024.into();
-		assert_eq!(june_17th_2024, ifc.into(), "ifc IR was {ifc:?}");
+		assert_eq!(
+			june_17th_2024,
+			ifc.into(),
+			"ifc IR was {ifc:?}, ordinal: {}",
+			ifc.ordinal()
+		);
 
 		let december_30th_2024 = time::Date::from_calendar_date(2024, time::Month::December, 30)?;
 		ifc = december_30th_2024.into();


### PR DESCRIPTION
the bug i fixed i call the 111th bug, where the ordinal 111th is incorrectly made into 111st. fixed by moduloing the number by 100 before assigning it an ordinal suffix.

the other bug i think has something to do with leap years and the placement of leap days in the sixth month or year days at the end of the year. i wrote a small but comprehensive round-trip checker to make sure that `time::Date -> crate::Date -> time::Date` is always a no-op and found some days where that isn't true, first ten examples below (first element of the tuple is the original gregdate, second is the ifcdate that it got turned `.into()`. i didn't really know how to fix it right now though :3 

```rust
[
	(2024-06-17, Date { year: 2024, month: 6, day: 29 }), 
	(2024-12-30, Date { year: 2024, month: 13, day: 29 }), 
	(2020-12-30, Date { year: 2020, month: 13, day: 29 }), 
	(2028-06-17, Date { year: 2028, month: 6, day: 29 }), 
	(2020-06-17, Date { year: 2020, month: 6, day: 29 }), 
	(2028-12-30, Date { year: 2028, month: 13, day: 29 }), 
	(2016-12-30, Date { year: 2016, month: 13, day: 29 }), 
	(2032-06-17, Date { year: 2032, month: 6, day: 29 }), 
	(2016-06-17, Date { year: 2016, month: 6, day: 29 }), 
	(2032-12-30, Date { year: 2032, month: 13, day: 29 })
]

```